### PR TITLE
Make extraction of offsets compatible with Linux

### DIFF
--- a/Offsets/requirements.txt
+++ b/Offsets/requirements.txt
@@ -1,2 +1,2 @@
 requests
-pywin32
+pefile

--- a/Offsets/requirements.txt
+++ b/Offsets/requirements.txt
@@ -1,2 +1,1 @@
 requests
-pefile


### PR DESCRIPTION
Currently `ExtractOffsets.py` relies on `win32api` which is a Windows-only library.

I removed this dependency to use Radare2 instead (as already started in comments) and I normalized the use of `subprocess.run` to be compatible with Linux and Windows.

Finally, i tested the script with Radare2 5.0.0 and it works well: I updated the minimal version to prevent the warning.