### PR TITLE
Fix potential buffer overrun in credguard disable

### DIFF
--- a/EDRSandblast/LSASSProtectionBypass/CredGuard.c
+++ b/EDRSandblast/LSASSProtectionBypass/CredGuard.c
@@ -54,7 +54,7 @@ DWORD WINAPI disableCredGuardByPatchingLSASS(void) {
     BOOL returnStatus = FALSE;
     TCHAR szModulename[MAX_PATH];
     for (DWORD i = 0; i < (lpcbNeeded / sizeof(HMODULE)); i++) {
-        if (hModulesArray[i] && !GetModuleFileNameEx(hLsass, hModulesArray[i], szModulename, MAX_PATH)) {
+        if (hModulesArray[i] && !GetModuleFileNameEx(hLsass, hModulesArray[i], szModulename, _countof(szModulename))) {
             _tprintf(TEXT("[!] Cred Guard bypass non fatal error: couldn't get module name for module at index 0x%lx (GetModuleFileNameEx, error code 0x%lx)\n"), i, GetLastError());
             continue;
         }

--- a/EDRSandblast/LSASSProtectionBypass/CredGuard.c
+++ b/EDRSandblast/LSASSProtectionBypass/CredGuard.c
@@ -54,7 +54,7 @@ DWORD WINAPI disableCredGuardByPatchingLSASS(void) {
     BOOL returnStatus = FALSE;
     TCHAR szModulename[MAX_PATH];
     for (DWORD i = 0; i < (lpcbNeeded / sizeof(HMODULE)); i++) {
-        if (hModulesArray[i] && !GetModuleFileNameEx(hLsass, hModulesArray[i], szModulename, sizeof(szModulename))) {
+        if (hModulesArray[i] && !GetModuleFileNameEx(hLsass, hModulesArray[i], szModulename, MAX_PATH)) {
             _tprintf(TEXT("[!] Cred Guard bypass non fatal error: couldn't get module name for module at index 0x%lx (GetModuleFileNameEx, error code 0x%lx)\n"), i, GetLastError());
             continue;
         }


### PR DESCRIPTION
The call to `GetModuleFileNameEx` passes in `sizeof(szModulename)` for the size parameter. The documentation for that API says the size parameter is a character count, not a byte count ("The size of the lpFilename buffer, in characters.").  Since the code currently passes in a byte count, this opens up the possibility for a stack buffer overrun on UNICODE compilations of this tool where the `szModulename` buffer will be MAX_PATH characters (2 * MAX_PATH bytes), but the size parameter wil indicate it is 2*MAX_PATH characters which `GetModuleFileNameEx` will interpret as a character count and potentially write up to `2*2*MAX_PATH` bytes into the buffer.  Fix by passing in a character count.  You could also use a macro like `ARRAYSIZE(szModulename)`.


```diff
    TCHAR szModulename[MAX_PATH];
    for (DWORD i = 0; i < (lpcbNeeded / sizeof(HMODULE)); i++) {
        if (hModulesArray[i] && !GetModuleFileNameEx(hLsass, hModulesArray[i], szModulename, sizeof(szModulename))) {
...        }
```

[1] Docs for GetModuleFileNameEx are here (https://docs.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmodulefilenameexa)