### PR TITLE
New EDR drivers

### DIFF
--- a/EDRSandblast/Utils/IsEDRChecks.c
+++ b/EDRSandblast/Utils/IsEDRChecks.c
@@ -139,6 +139,7 @@ TCHAR const* EDR_DRIVERS[] = {
    _T("Atc.sys"),
    _T("AVC3.SYS"),
    _T("TRUFOS.SYS"),
+   _T("BDSandBox.sys"),
    // Bkav Corporation
    _T("BkavAutoFlt.sys"),
    _T("BkavSdFlt.sys"),
@@ -371,6 +372,9 @@ TCHAR const* EDR_DRIVERS[] = {
    _T("mfencoas.sys"),
    _T("mfehidk.sys"),
    _T("swin.sys"),
+   _T("MfeEEFF.sys"),
+   _T("mfprom.sys"),
+   _T("hdlpflt.sys"),
    // Meidensha Corp
    _T("WhiteShield.sys"),
    // Microsoft
@@ -537,6 +541,7 @@ TCHAR const* EDR_DRIVERS[] = {
    _T("TmEsFlt.sys"),
    _T("TmEyes.sys"),
    _T("tmevtmgr.sys"),
+   _T("TmFileEncDmk.sys"),
    // Verdasys Inc
    _T("STKrnl64.sys"),
    // VisionPower Co.,Ltd.
@@ -581,6 +586,9 @@ TCHAR const* EDR_DRIVERS[] = {
    _T("Qutmdrv.sys"),
    // Absolute Software
    _T("cbfsfilter2017.sys"),
+   _T("psepfilter.sys"),
+   // Absolute Software Corp.
+   _T("cve.sys"),
    // Acronis
    _T("NgScan.sys"),
    // Actifio Inc
@@ -750,8 +758,12 @@ TCHAR const* EDR_DRIVERS[] = {
    // Check Point Software
    _T("epregflt.sys"),
    _T("epklib.sys"),
+   _T("medlpflt.sys"),
+   _T("dsfa.sys"),
+   _T("cposfw.sys"),
    // Checkpoint Software
    _T("cpepmon.sys"),
+   _T("cpbak.sys"),
    // ChemoMetec
    _T("ChemometecFilter.sys"),
    // Cigent Technology Inc
@@ -1476,6 +1488,7 @@ TCHAR const* EDR_DRIVERS[] = {
    _T("symevent.sys"),
    // Symantec Corp.
    _T("diflt.sys"),
+   _T("SISIPSFileFilter.sys"),
    // Syncopate
    _T("thetta.sys"),
    // Systemneeds, Inc
@@ -1627,6 +1640,8 @@ TCHAR const* EDR_DRIVERS[] = {
    _T("ctifile.sys"),
    _T("ctinet.sys"),
    _T("parity.sys"),
+   _T("cbstream.sys"),
+   _T("cbk7.sys"),
    // Cisco
    _T("csacentr.sys"),
    _T("csaenh.sys"),
@@ -1676,6 +1691,7 @@ TCHAR const* EDR_DRIVERS[] = {
    _T("symrg.sys"),
    // Verdasys Inc
    _T("ndgdmk.sys"),
+   _T("dgdmk.sys"),
    /*
    * Invoke-EDRCheck.ps1 - END
    */


### PR DESCRIPTION
This commit add some EDR drivers: BDSandBox.sys (BitDefender), MfeEEFF.sys mfprom.sys hdlpflt.sys (McAfee Inc.), TmFileEncDmk.sys (Trend Micro Inc.), psepfilter.sys (Absolute Software), cve.sys (Absolute Software Corp.), medlpflt.sys dsfa.sys cposfw.sys (Check Point Software), cpbak.sys (Checkpoint Software), SISIPSFileFilter.sys (Symantec Corp.), cbstream.sys cbk7.sys (Carbon Black) and dgdmk.sys (Verdasys Inc)