### PR TITLE
Fix current build

### DIFF
--- a/EDRSandblast/UserlandBypass/ProcessDumpDirectSyscalls.c
+++ b/EDRSandblast/UserlandBypass/ProcessDumpDirectSyscalls.c
@@ -7,6 +7,7 @@
 #include "StringUtils.h"
 #include "SyscallProcessUtils.h"
 #include "SW2_Syscalls.h"
+#include "ProcessDump.h"
 #include "Undoc.h"
 
 #include "ProcessDumpDirectSyscalls.h"


### PR DESCRIPTION
Currently, building the project yields an error for the undefined `SetPrivilege` function. This PR fixes the build.