### PR TITLE
Update EDRSandblast_API.c - MiniFilter Callbacks not restored see issue #30

### DIFF
--- a/EDRSandblast_StaticLibrary/EDRSandblast_API.c
+++ b/EDRSandblast_StaticLibrary/EDRSandblast_API.c
@@ -425,7 +425,7 @@ EDRSB_STATUS Krnlmode_RestoreAllMonitoring(_In_ EDRSB_CONTEXT* ctx) {
 
     if (!ctx->config->actions.DontRestoreCallBacks && ctx->foundMinifilterCallbacks) {
         _putts_or_not(TEXT("[+] Restoring EDR's minifilter callbacks..."));
-        EnableEDRProcessAndThreadObjectsCallbacks(ctx->foundEDRDrivers);
+		RestoreEDRMinifilterCallbacks(ctx->foundEDRDrivers);
     }
 
     // Renable the ETW Threat Intel provider.


### PR DESCRIPTION
The wrong function is called. See issue #30.